### PR TITLE
Updated pyroscope-io to 0.8.8 with 3.12 and 3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,6 @@ requires-python = ">= 3.8"
 dependencies = [
   "opentelemetry-api>=1.27.0, <2.0.0",
   "opentelemetry-sdk>=1.27.0, <2.0.0",
-  "pyroscope-io==0.8.7"
+  "pyroscope-io==0.8.8"
 ]
 license = {file = "LICENSE"}


### PR DESCRIPTION
Updated pyroscope-io to support Python 3.12 and 3.13.

see: https://github.com/grafana/pyroscope-rs/releases/tag/python-0.8.8