### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Register the `PyroscopeSpanProcessor` in your OpenTelemetry integration:
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
-from pyroscope-otel import PyroscopeSpanProcessor
+from pyroscope.otel import PyroscopeSpanProcessor
 
 provider = TracerProvider()
 provider.add_span_processor(PyroscopeSpanProcessor())


### PR DESCRIPTION
Example usage is incorrect

There was an issue for this but looks like the readme is still wrong: https://github.com/grafana/otel-profiling-python/issues/2