### PR TITLE
Update pyproject.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.12
       - name: Install build
         run: pip install build
       - name: Build wheel and sdist
         run: python -m build --sdist --wheel
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,6 @@ requires-python = ">= 3.8"
 dependencies = [
   "opentelemetry-api>=1.27.0, <2.0.0",
   "opentelemetry-sdk>=1.27.0, <2.0.0",
-  "pyroscope-io==0.8.8"
+  "pyroscope-io>=0.8.10"
 ]
 license = {file = "LICENSE"}


### PR DESCRIPTION
This should allow using different sdk versions without forcing us to regularly update the strict equality dependency here
Fixes https://github.com/grafana/otel-profiling-python/issues/13
Fixes https://github.com/grafana/pyroscope/actions/runs/14849975898/job/41691636834 Thanks to examples tests suite <3