### PR TITLE
chore: Switch to self-hosted GitHub agents

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: write
     steps:
@@ -40,7 +40,7 @@ jobs:
           asset_path: "dist/*"
   publish:
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Updated GitHub workflow files to use self-hosted agents instead of GitHub-hosted runners