### PR TITLE
Revise README for Pyroscope and OpenTelemetry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ provider.add_span_processor(PyroscopeSpanProcessor())
 # from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 #
 # otlp_exporter = OTLPSpanExporter(
-#     endpoint="tempo-blocks-prod-us-central-1.grafana-cloud.com:443",
+#     endpoint="<your-tempo-instance>.grafana.net:443",
 #     headers=(("Authorization", "Bearer <your-grafana-cloud-token>"),),
 # )
 # provider.add_span_processor(BatchSpanProcessor(otlp_exporter))


### PR DESCRIPTION
Hi guys, I had some difficulties understanding the complete setup when I first tried to implement this lib. I think the docs can be improved, and that's what I'm proposing in this PR.

## What's improved:

**1. Dedicated Pyroscope Configuration Section** - Made clear it must be configured first, with local and Grafana Cloud examples

**2. Authentication Parameters** - Added `basic_auth_username` and `basic_auth_password` documentation for Grafana Cloud

**3. Merged "How It Works" & "Span Attributes"** - Clearer explanation of how `pyroscope.profile.id` links traces to Grafana Tempo

**4. Automatic Instrumentation Guide** - Explicit note that auto-instrumentation still requires manual `PyroscopeSpanProcessor` registration

**5. Cleaner Structure** - Better flow: Pyroscope → OpenTelemetry → exporter

I'm open to any changes or improvements!