### PR TITLE
Fix PyroscopeSpanProcessor compatibility with pyroscope-io 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,6 @@ requires-python = ">= 3.8"
 dependencies = [
   "opentelemetry-api>=1.27.0, <2.0.0",
   "opentelemetry-sdk>=1.27.0, <2.0.0",
-  "pyroscope-io>=0.8.10"
+  "pyroscope-io>=1.0.0, <2.0.0"
 ]
 license = {file = "LICENSE"}

--- a/src/pyroscope/otel/__init__.py
+++ b/src/pyroscope/otel/__init__.py
@@ -1,5 +1,4 @@
 import typing
-import threading
 
 from opentelemetry.sdk.trace import (
     Span,
@@ -28,13 +27,13 @@ class PyroscopeSpanProcessor(SpanProcessor):
     ) -> None:
         if _is_root_span(span):
             span.set_attribute(PROFILE_ID_SPAN_ATTRIBUTE_KEY, format(span.context.span_id, "016x"))
-            pyroscope.add_thread_tag(threading.get_ident(), PROFILE_ID_PYROSCOPE_TAG_KEY, _get_span_id(span))
-            pyroscope.add_thread_tag(threading.get_ident(), SPAN_NAME_PYROSCOPE_TAG_KEY, span.name)
+            pyroscope.add_thread_tag(PROFILE_ID_PYROSCOPE_TAG_KEY, _get_span_id(span))
+            pyroscope.add_thread_tag(SPAN_NAME_PYROSCOPE_TAG_KEY, span.name)
 
     def on_end(self, span: ReadableSpan) -> None:
         if _is_root_span(span):
-            pyroscope.remove_thread_tag(threading.get_ident(), PROFILE_ID_PYROSCOPE_TAG_KEY, _get_span_id(span))
-            pyroscope.remove_thread_tag(threading.get_ident(), SPAN_NAME_PYROSCOPE_TAG_KEY, span.name)
+            pyroscope.remove_thread_tag(PROFILE_ID_PYROSCOPE_TAG_KEY, _get_span_id(span))
+            pyroscope.remove_thread_tag(SPAN_NAME_PYROSCOPE_TAG_KEY, span.name)
 
     def shutdown(self) -> None:
         pass


### PR DESCRIPTION
## Summary

Fixes a runtime `TypeError` when using `pyroscope-otel` with `pyroscope-io 1.x`.

## What changed

- **`src/pyroscope/otel/__init__.py`**: Updated all calls to `add_thread_tag` and `remove_thread_tag` to use the new 2-argument signature `(key, value)` instead of the old 3-argument signature `(thread_id, key, value)`. Removed the now-unused `threading` import.
- **`pyproject.toml`**: Tightened the `pyroscope-io` dependency from `>=0.8.10` (unbounded) to `>=1.0.0, <2.0.0` to pin to the major version that introduced this API change and guard against future breaking changes.

## Why

`pyroscope-io 1.0.x` introduced a breaking change: `add_thread_tag` and `remove_thread_tag` dropped the `thread_id` first parameter (the library now infers the current thread internally). The previous unbounded dependency specifier allowed `pyroscope-io 1.x` to be installed alongside `pyroscope-otel`, causing:

```
TypeError: add_thread_tag() takes 2 positional arguments but 3 were given
```

Closes #30